### PR TITLE
api.py: Fix __iter__ bug in IterResource class

### DIFF
--- a/appstoreconnect/api.py
+++ b/appstoreconnect/api.py
@@ -210,6 +210,7 @@ class Api:
 				return items[item]
 
 			def __iter__(self):
+				self.index = 0
 				return self
 
 			def __repr__(self):


### PR DESCRIPTION
The __iter__ method needs to reset the index when called in case a
previous iterator didn't complete a full cycle of all elements.